### PR TITLE
Fix 'unused-result' warning on GCC

### DIFF
--- a/death_handler.cc
+++ b/death_handler.cc
@@ -706,7 +706,8 @@ void DeathHandler::HandleSignal(int sig, void * /* info */, void *secret) {
 
   // Write '\0' to indicate the end of the output
   char end = '\0';
-  write(STDERR_FILENO, &end, 1);
+  ssize_t ret = write(STDERR_FILENO, &end, 1);
+  (void)ret;
 
 #elif defined(__APPLE__)
   for (int i = 0; i < trace_size; i++) {


### PR DESCRIPTION
Fixes a GCC warning that becomes an error when using `-Werror`:

```
death_handler.cc: In static member function ‘static void Debug::DeathHandler::HandleSignal(int, void*, void*)’:
death_handler.cc:709:8: error: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Werror=unused-result]
  709 |   write(STDERR_FILENO, &end, 1);
      |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```

I.e. the return value of `write()` must be retrieved, but in current code it is not.

This change simply keeps the same behavior, but making it explicit, thus it conveys better the intention, and avoids the warning.